### PR TITLE
Touch media folders to force a media sync

### DIFF
--- a/src/editExternal.py
+++ b/src/editExternal.py
@@ -8,6 +8,8 @@ import json
 import types
 import time
 
+from pathlib import Path
+
 from anki.hooks import addHook
 from anki.utils import isMac, isWin, isLin
 from aqt import mw
@@ -110,6 +112,8 @@ def _editExternal(editor, fname, type, field):
         if external_program:
             open_in_external(fileabspath, external_program)
 
+    Path(mediafolder).touch()
+
 
 def new_and_edit_image(editor):
     template = gc("image_empty_insert_and_edit__file_from_user_files")
@@ -174,6 +178,8 @@ def editDiaMMExternal(editor, field, prog, template, f):
         # in 2019-06 freeplane needs False if openend with freeplane.sh
         open_in_external(f.sourcepath, prog, False)
 
+    Path(mediafolder).touch()
+
 
 def new_and_edit(editor, arg):
     if arg == "ni":
@@ -210,3 +216,5 @@ $('img').each(function(){
         """ % token)
     else:
         open_in_external(fileabspath, external_program)
+
+    Path(mediafolder).touch()


### PR DESCRIPTION
If files are changed with the an external editor then the media files are not synced to Anki Web (at least under Linux, it might be that in Windows or OS X the behaviour is different).

Drilling down it seems that `rslib/src/media/changetracker.rs` checks for the mtime of mediafolder.
If that has not changed, it skips the sync of the media files (resp. skips the check if files changed).
A simple touch() makes it sync the media files if they changed, this should be save also for other OS'es.