### PR TITLE
Improve macOS compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/src/config.md
+++ b/src/config.md
@@ -1,4 +1,5 @@
 - In windows in file paths you need to replace `\` with `\\` e.g. `"C:\\Program Files (x86)\\Audacity\\audacity.exe` 
+- In macOS, use absolute paths to external editor applications. For example, if you use Audacity, the path should be `/Applications/Audacity.app`
 
 #### when problems occur
 If you have problems with this add-on: <br/>

--- a/src/editExternal.py
+++ b/src/editExternal.py
@@ -44,7 +44,7 @@ def open_in_external(fileabspath, external_program, shell=True):
     env = env_adjust()
     if isMac:
         cmd = f"open -a {external_program} '{fileabspath}'"
-        subprocess.run(shlex.split(cmd), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(shlex.split(cmd), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
     else:
         # in 2019-12 I have no idea why I used shell=True by default in 2019-05.
         if shell:

--- a/src/rename.py
+++ b/src/rename.py
@@ -13,6 +13,13 @@ if anki_point_version >= 45:
 if anki_point_version <= 28:
     from anki.find import findReplace
 
+if anki_point_version <= 49:
+    from anki.utils import isMac
+    from anki.utils import isWin
+else:
+    from anki.utils import is_mac as isMac
+    from anki.utils import is_win as isWin
+
 from aqt import mw
 from aqt.utils import tooltip
 
@@ -133,7 +140,12 @@ def rename(editor, fname, type, field):
             notify_user(cnt, fname, newfilename)
 
             if not os.path.isfile(newfilename):
-                os.rename(fname, newfilename)
+                if isMac:
+                    fname_ = os.path.join(mediafolder, fname)
+                    newfilename_ = os.path.join(mediafolder, newfilename)
+                    os.rename(fname_, newfilename_)
+                else:
+                    os.rename(fname, newfilename)
             backup_changed_filenames(fname, newfilename)
             
             # update editor


### PR DESCRIPTION
The rename feature on the macOS side seems to require the addition of the media directory path to the old and new paths before the actual filesystem rename. I don't have a Windows machine to test whether this behaviour is also an issue on the Windows or Linux side, too. Therefore, I just placed an `isMac` test to bifurcate the rename functionality at that point.

The edit externally functionality has similar issues, requiring an absolute path to the editing application. It's also a little forgiving now on macOS, if the user forgets to provide the absolute path (+ the .app extension), we now attempt to correct that. Failing that, we look in `~/Applications`, finally just falling back to the user-provide (likely erroneous) editor path. Also, documentation change to reflect the need for absolute tool paths on macOS. Thanks NSBum (aka OjisanSeiuchi)