### PR TITLE
Patches for macOS

### DIFF
--- a/src/editExternal.py
+++ b/src/editExternal.py
@@ -43,7 +43,8 @@ addHook("profileLoaded", some_paths)
 def open_in_external(fileabspath, external_program, shell=True):
     env = env_adjust()
     if isMac:
-        cmd = f"open -a {external_program} '{fileabspath}'"
+        # 2022-09-09 quote the external_program for spaces in executable path name
+        cmd = f"open -a '{external_program}' '{fileabspath}'"
         subprocess.run(shlex.split(cmd), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
     else:
         # in 2019-12 I have no idea why I used shell=True by default in 2019-05.

--- a/src/helper.py
+++ b/src/helper.py
@@ -16,6 +16,12 @@ from aqt.utils import getText, tooltip, showInfo
 
 from .config import gc
 
+from .config import anki_point_version, gc
+if anki_point_version <= 49:
+    from anki.utils import isMac
+else:
+    from anki.utils import is_mac as isMac
+    
 
 def browser_parents():
     relevant_parents = [Browser]

--- a/src/helper.py
+++ b/src/helper.py
@@ -195,6 +195,16 @@ def env_adjust():
 
 
 def check_if_executable_exists(file):
+    # 2022-09-09 shutil does not provide executable path on macOS
+    # therefore just test for existence and hope for the best
+    if isMac:
+        if not os.path.exists(file):
+            msg = f'{file} does not point to a macOS application. Aborting...'
+            print(msg)
+            tooltip(msg)
+            return
+        else:
+            return file
     called = shutil.which(file)
     if not (called and os.path.isfile(called)):
         msg = f'{file} does not point to a callable file. Aborting ...'


### PR DESCRIPTION
Additional patches for macOS compatibility:

- quote executable path before attempting to execute `open` as required for macOS applications that have spaces in the name
- do not attempt to apply `shutil.which()` on macOS because it fails. Instead, just check for the existence of the path in the filesystem and only bail if existence check fails. It's not ideal but since `which` doesn't work with macOS application bundles, that's about all we can do on that platform.

_NSBum (aka OjisanSeiuchi)_